### PR TITLE
remove development files and documentation, unnecessary at runtime

### DIFF
--- a/io.otsaloma.gaupol.yml
+++ b/io.otsaloma.gaupol.yml
@@ -12,6 +12,17 @@ finish-args:
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=x11
+cleanup:
+  - '*.la'
+  - /lib/pkg-config
+  - /lib/*.a
+  - /share/doc
+  - /share/man
+  - /share/gtk-doc
+  - /share/ffmpeg
+  - /share/gir-1.0
+  - /share/vala
+  - /share/zsh
 modules:
 
   # Internal video player codecs


### PR DESCRIPTION
This reduces the app size by more than 60%